### PR TITLE
群消息解析改进

### DIFF
--- a/src/main/java/com/scienjus/smartqq/model/GroupMessage.java
+++ b/src/main/java/com/scienjus/smartqq/model/GroupMessage.java
@@ -5,8 +5,10 @@ import com.alibaba.fastjson.JSONObject;
 import lombok.Data;
 
 /**
- * 群消息
+ * 群消息.
+ *
  * @author ScienJus
+ * @author <a href="http://88250.b3log.org">Liang Ding</a>
  * @date 15/12/19.
  */
 @Data
@@ -23,9 +25,15 @@ public class GroupMessage {
     private Font font;
 
     public GroupMessage(JSONObject json) {
-        JSONArray content = json.getJSONArray("content");
-        this.font = content.getJSONArray(0).getObject(1, Font.class);
-        this.content = content.getString(1);
+        JSONArray cont = json.getJSONArray("content");
+        this.font = cont.getJSONArray(0).getObject(1, Font.class);
+
+        if (2 == cont.size()) { // 接收群内普通消息
+            this.content = cont.getString(1);
+        } else if (4 == cont.size()) { // 接收群内 @用户 的消息
+            this.content = cont.getString(3);
+        }
+
         this.time = json.getLongValue("time");
         this.groupId = json.getLongValue("group_code");
         this.userId = json.getLongValue("send_uin");


### PR DESCRIPTION
解析群消息时存在一点问题：如果群消息是 @用户 的，那么 content 的解析不对

现在可以正常解析了 :grapes: 