### PR TITLE
删除“使用默认软件打开二维码”的部分，linux服务器上会报错

### DIFF
--- a/src/main/java/com/scienjus/smartqq/client/SmartQQClient.java
+++ b/src/main/java/com/scienjus/smartqq/client/SmartQQClient.java
@@ -128,15 +128,6 @@ public class SmartQQClient implements Closeable {
             }
         }
         LOGGER.info("二维码已保存在 " + filePath + " 文件中，请打开手机QQ并扫描二维码");
-
-        //使用默认软件打开二维码
-        Desktop desk = Desktop.getDesktop();
-        try {
-            File file = new File(filePath);
-            desk.open(file);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
     }
 
     //用于生成ptqrtoken的哈希函数


### PR DESCRIPTION
考虑到很多生产系统都是linux的，没有桌面程序，将此处删除