### PR TITLE
api请求不再返回errcode

### DIFF
--- a/src/main/java/com/scienjus/smartqq/client/SmartQQClient.java
+++ b/src/main/java/com/scienjus/smartqq/client/SmartQQClient.java
@@ -651,7 +651,7 @@ public class SmartQQClient implements Closeable {
             LOGGER.error(String.format("发送失败，Http返回码[%d]", response.getStatusCode()));
         }
         JSONObject json = JSON.parseObject(response.getBody());
-        Integer errCode = json.getInteger("errCode");
+        Integer errCode = json.getInteger("redcode");
         if (errCode != null && errCode == 0) {
             LOGGER.debug("发送成功");
         } else {

--- a/src/main/java/com/scienjus/smartqq/client/SmartQQClient.java
+++ b/src/main/java/com/scienjus/smartqq/client/SmartQQClient.java
@@ -63,6 +63,7 @@ public class SmartQQClient implements Closeable {
     //线程开关
     private volatile boolean pollStarted;
 
+
     public SmartQQClient(final MessageCallback callback) {
         this.client = Client.pooled().maxPerRoute(5).maxTotal(10).build();
         this.session = client.session();
@@ -651,7 +652,7 @@ public class SmartQQClient implements Closeable {
             LOGGER.error(String.format("发送失败，Http返回码[%d]", response.getStatusCode()));
         }
         JSONObject json = JSON.parseObject(response.getBody());
-        Integer errCode = json.getInteger("redcode");
+        Integer errCode = json.getInteger("retcode");
         if (errCode != null && errCode == 0) {
             LOGGER.debug("发送成功");
         } else {


### PR DESCRIPTION
发送消息输出log，发送消息失败，我看一下网络请求，发现发送消息response没有errcode：

![image](https://user-images.githubusercontent.com/19546964/30357837-7252d8ea-9873-11e7-97b4-aff79589933d.png)

然后简单改一下输出log判断的逻辑。

额对于抓包什么的不是很懂。